### PR TITLE
chore: fix typos

### DIFF
--- a/schema/json/window-style.schema.json
+++ b/schema/json/window-style.schema.json
@@ -19,7 +19,7 @@
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "horizonal": { "type": "number" },
+                    "horizontal": { "type": "number" },
                     "vertical": { "type": "number" }
                   },
                   "required": ["horizontal", "vertical"]

--- a/scripts/color-table.sh
+++ b/scripts/color-table.sh
@@ -2,7 +2,7 @@
 #
 #   This file echoes a bunch of color codes to the
 #   terminal to demonstrate what's available.  Each
-#   line is the color code of one forground color,
+#   line is the color code of one foreground color,
 #   out of 17 (default + 16 escapes), followed by a
 #   test use of that color on all nine background
 #   colors (default + 8 escapes).


### PR DESCRIPTION
Found via `typos --hidden --format brief`