### PR TITLE
fix: fix shadow clipping at small window heights

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.vscode
 /.tmp
+/.zed
 /target
 /output.svg
 /*.ansi

--- a/assets/test/output/color-table.svg
+++ b/assets/test/output/color-table.svg
@@ -1,6 +1,6 @@
 <svg height="452" width="659.2" xmlns="http://www.w3.org/2000/svg">
 <g transform="translate(32,16)">
-<filter id="shadow">
+<filter filterUnits="userSpaceOnUse" height="460" id="shadow" width="667.2" x="-32" y="-24">
 <feGaussianBlur stdDeviation="12"/>
 </filter>
 <rect fill="#000000c0" filter="url(#shadow)" height="388" rx="10" ry="10" width="595.2" x="4" y="12"/>

--- a/assets/test/output/lsd.svg
+++ b/assets/test/output/lsd.svg
@@ -1,6 +1,6 @@
 <svg height="452" width="659.2" xmlns="http://www.w3.org/2000/svg">
 <g transform="translate(32,16)">
-<filter id="shadow">
+<filter filterUnits="userSpaceOnUse" height="460" id="shadow" width="667.2" x="-32" y="-24">
 <feGaussianBlur stdDeviation="12"/>
 </filter>
 <rect fill="#000000c0" filter="url(#shadow)" height="388" rx="10" ry="10" width="595.2" x="4" y="12"/>

--- a/assets/test/output/sample.svg
+++ b/assets/test/output/sample.svg
@@ -1,6 +1,6 @@
 <svg height="452" width="659.2" xmlns="http://www.w3.org/2000/svg">
 <g transform="translate(32,16)">
-<filter id="shadow">
+<filter filterUnits="userSpaceOnUse" height="460" id="shadow" width="667.2" x="-32" y="-24">
 <feGaussianBlur stdDeviation="12"/>
 </filter>
 <rect fill="#000000c0" filter="url(#shadow)" height="388" rx="10" ry="10" width="595.2" x="4" y="12"/>

--- a/src/render/svg.rs
+++ b/src/render/svg.rs
@@ -409,9 +409,19 @@ fn make_window(opt: &Options, width: f32, height: f32, screen: element::SVG) -> 
     if cfg.window.shadow && opt.window.shadow.enabled {
         let shadow = &opt.window.shadow;
         window = window
-            .add(element::Filter::new().set("id", "shadow").add(
-                element::FilterEffectGaussianBlur::new().set("stdDeviation", shadow.blur.r2p(fp)),
-            ))
+            .add(
+                element::Filter::new()
+                    .set("id", "shadow")
+                    .set("filterUnits", "userSpaceOnUse")
+                    .set("x", "-32")
+                    .set("y", "-24")
+                    .set("width", (width + 72.0).r2p(fp))
+                    .set("height", (height + 72.0).r2p(fp))
+                    .add(
+                        element::FilterEffectGaussianBlur::new()
+                            .set("stdDeviation", shadow.blur.r2p(fp)),
+                    ),
+            )
             .add(
                 element::Rectangle::new()
                     .set("width", width)


### PR DESCRIPTION
Fixes the shadow clipping issue at small window heights.

### Before
![1](https://github.com/user-attachments/assets/b19acfe2-4e35-4aae-abd5-56bb46ed7d2a)

### After
![2](https://github.com/user-attachments/assets/ae0a7122-0c60-40e5-bcdc-83b2b5d07f89)
