### PR TITLE
build: add automatic schema URL replacement in TOML files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,20 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
 
+      - name: Setup taplo
+        uses: uncenter/setup-taplo@4f203fdb4f3b1e289c8382cf90d8397d2338df2e # v1.0.8
+
+      - name: Setup tombi
+        uses: tombi-toml/setup-tombi@f7cb38e77d9a62bc27a8445bf50e660e9496b893 # v1.0.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Validate TOML configs and themes with taplo
+        run: taplo check
+
+      - name: Validate TOML configs and themes with tombi
+        run: tombi lint
+
       - name: Run Clippy
         run: cargo clippy --locked --all-targets --all-features
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,11 +113,26 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Update schema references in TOML files
+        run: |
+          VERSION=${{ steps.update-version.outputs.version }}
+
+          # Find all TOML files with schema references (both relative and absolute) and update them
+          # Matches both:
+          # - Relative: #:schema (../)+schema/...
+          # - Absolute: #:schema https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/[ref]/schema/...
+          find . -name "*.toml" -type f -exec grep -l "#:schema" {} \; | while read -r file; do
+            echo "Updating schema reference in ${file}"
+            sed -i.bak -E 's|#:schema ((\.\./)+\|https://raw\.githubusercontent\.com/${{ github.repository_owner }}/${{ github.repository }}/[^/]+/)schema/|#:schema https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/v'"${VERSION}"'/schema/|g' "${file}"
+            rm -f "${file}.bak"
+          done
+
       - name: Commit version update
         run: |
           git config --local user.name "missionis[bot]"
           git config --local user.email "234988995+missionis[bot]@users.noreply.github.com"
           git add Cargo.toml Cargo.lock
+          git add -u "*.toml" || true
           git commit -m "chore(release): bump version to ${{ steps.update-version.outputs.version }}"
           git push origin "refs/heads/${{ steps.create-temp-branch.outputs.branch }}"
 

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -14,6 +14,5 @@ schema = { path = "./schema/json/window-style.schema.json", enabled = true }
 include = ["**/Cargo.toml"]
 
 [rule.formatting]
-indent = 4
 reorder_keys = false
 column_width = 160

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "termframe"
-version = "0.7.5-alpha.1"
+version = "0.7.5-alpha.2"
 dependencies = [
  "allsorts",
  "anyhow",
@@ -2903,6 +2903,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_plain",
+ "sha2",
  "shell-escape",
  "strsim",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,23 +1,27 @@
-[workspace]
-members = [".", "tools/tidy-themes"]
-default-members = ["."]
-resolver = "2"
-
 [package]
 name = "termframe"
-authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
-description = "Terminal output SVG screenshot tool"
-categories = ["command-line-utilities"]
-keywords = ["cli", "terminal", "screenshot", "svg"]
-version = "0.7.5-alpha.1"
+version = "0.7.5-alpha.2"
 edition = "2024"
+rust-version = "1.88.0"
+description = "Terminal output SVG screenshot tool"
 license = "MIT"
+keywords = ["cli", "screenshot", "svg", "terminal"]
+categories = ["command-line-utilities"]
 build = "build/build.rs"
 default-run = "termframe"
-rust-version = "1.88.0"
 
-[build-dependencies]
-tidy-themes = { path = "tools/tidy-themes" }
+[workspace]
+resolver = "2"
+members = [".", "tools/tidy-themes"]
+default-members = ["."]
+
+[lib]
+name = "termframe"
+path = "src/lib.rs"
+
+[[bin]]
+name = "termframe"
+path = "src/main.rs"
 
 [dependencies]
 allsorts = "0.15"
@@ -25,17 +29,20 @@ anyhow = "1"
 askama = "0.15"
 base64 = "0.22"
 cacache = "13"
-clap = { version = "4", features = ["wrap_help", "derive", "env", "string"] }
+clap = { version = "4", features = ["derive", "env", "string", "wrap_help"] }
 clap_complete = "4"
 clap_mangen = "0.2"
 closure = "0.3"
-config = { version = "0.15", features = ["yaml", "json", "toml"] }
+config = { version = "0.15", features = ["json", "toml", "yaml"] }
 csscolorparser = { version = "0.7", features = ["serde"] }
 dark-light = "2"
 dirs = "6"
 dirs-sys = "0.5"
 enumset = "1"
-enumset-ext = { git = "https://github.com/pamburus/hl.git", rev = "9ba780e0d39288c0b412820599cc9816be980a28", features = ["serde", "clap"] }
+enumset-ext = { git = "https://github.com/pamburus/hl.git", rev = "9ba780e0d39288c0b412820599cc9816be980a28", features = [
+    "clap",
+    "serde"
+] }
 enumset-serde = { git = "https://github.com/pamburus/hl.git", rev = "9ba780e0d39288c0b412820599cc9816be980a28" }
 env_logger = "0.11"
 exponential-backoff = "2"
@@ -69,14 +76,12 @@ voca_rs = "1"
 wild = "2"
 yaml-peg = "1"
 
+[build-dependencies]
+anyhow = "1"
+sha2 = "0.10"
+tidy-themes = { path = "tools/tidy-themes" }
+ureq = "3"
+
 [patch.crates-io]
 pathfinder_simd = { git = "https://github.com/servo/pathfinder.git", rev = "8ccf6f7c2dd91f8e143998f91e55d1d24a4709bd" }
 svg = { git = "https://github.com/pamburus/svg.git", rev = "f9ac3f53d6747d8af57f16d447a7336779ddb722" }
-
-[lib]
-name = "termframe"
-path = "src/lib.rs"
-
-[[bin]]
-name = "termframe"
-path = "src/main.rs"

--- a/assets/config.toml
+++ b/assets/config.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/pamburus/termframe/refs/heads/main/schema/json/config.schema.json
+#:schema ../schema/json/config.schema.json
 
 # Dark or light mode.
 # Possible values: [auto, dark, light].
@@ -28,7 +28,7 @@ mode = "auto"
 # - Preferred size that gets clamped to min/max constraints if specified
 [terminal]
 width = { min = 80, max = 240, step = 4, initial = 180 } # Number of terminal columns.
-height = { min = 24, max = 60, initial = 48 }  # Number of terminal rows.
+height = { min = 24, max = 60, initial = 48 }            # Number of terminal rows.
 
 # Environment variables.
 [env]

--- a/assets/themes/One Double.toml
+++ b/assets/themes/One Double.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/pamburus/termframe/refs/heads/main/schema/json/theme.schema.json
+#:schema ../../schema/json/theme.schema.json
 
 tags = ["dark", "light"]
 

--- a/assets/window-styles/compact.toml
+++ b/assets/window-styles/compact.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/pamburus/termframe/refs/heads/main/schema/json/window-style.schema.json
+#:schema ../../schema/json/window-style.schema.json
 
 [window]
 margin = 8

--- a/assets/window-styles/macos.toml
+++ b/assets/window-styles/macos.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/pamburus/termframe/refs/heads/main/schema/json/window-style.schema.json
+#:schema ../../schema/json/window-style.schema.json
 
 [window.margin]
 left = 32

--- a/build/build.rs
+++ b/build/build.rs
@@ -1,7 +1,245 @@
+//! Build script for termframe
+//!
+//! This script performs the following tasks:
+//! - Automatically replaces HTTP(S) schema URLs in TOML files with relative paths
+//! - Updates theme aliases to their default values
+//!
+//! ## Schema URL Replacement
+//!
+//! Any TOML file in the assets directory that contains a schema directive like:
+//!   #:schema https://example.com/path/to/schema.json
+//!
+//! Will be automatically replaced with a relative path to the local schema file:
+//!   #:schema ../../schema/json/schema.json
+//!
+//! This replacement only occurs if:
+//! - The schema URL uses HTTP(S) protocol
+//! - A matching local schema file exists in schema/json/
+//! - The local schema file has a different SHA256 hash than the remote one
+//!   (or the remote fetch fails)
+
+use std::fs::{self, File};
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Result, anyhow};
+use sha2::{Digest, Sha256};
+
+const ASSETS_DIR: &str = "assets";
+const JSON_SCHEMA_DIR: &str = "schema/json";
+
 fn main() {
+    if let Err(e) = run() {
+        eprintln!("{:?}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    update_schema_directives()?;
+
     if let Err(e) = tidy_themes::update_theme_aliases_default() {
-        panic!("Failed to update theme aliases: {}", e);
+        return Err(anyhow!("Failed to update theme aliases: {}", e));
     }
 
     println!("cargo:rerun-if-changed=assets/themes");
+    Ok(())
 }
+
+/// Updates schema directives in all TOML files under the assets directory.
+/// Recursively processes all subdirectories.
+fn update_schema_directives() -> Result<()> {
+    update_toml_schema_urls_in_dir(Path::new(ASSETS_DIR))?;
+    Ok(())
+}
+
+/// Recursively processes a directory, updating schema URLs in all TOML files.
+fn update_toml_schema_urls_in_dir(dir: &Path) -> Result<()> {
+    for entry in fs::read_dir(dir)
+        .map_err(|e| anyhow!("Failed to read directory {}: {}", dir.display(), e))?
+    {
+        let entry = entry.map_err(|e| anyhow!("Failed to read directory entry: {}", e))?;
+        let path = entry.path();
+
+        if path.is_dir() {
+            update_toml_schema_urls_in_dir(&path)?;
+        } else if path.extension().and_then(|s| s.to_str()) == Some("toml") {
+            println!("cargo:rerun-if-changed={}", path.display());
+            update_toml_schema_url(&path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Updates the schema URL in a single TOML file if it uses HTTP(S) protocol.
+/// Replaces HTTP(S) URLs with relative paths to local schema files.
+fn update_toml_schema_url(toml_path: &Path) -> Result<()> {
+    const SCHEMA_PREFIX: &str = "#:schema ";
+
+    let content = fs::read_to_string(toml_path)
+        .map_err(|e| anyhow!("Failed to read TOML file {}: {}", toml_path.display(), e))?;
+
+    let schema_line = content
+        .lines()
+        .find(|line| line.trim().starts_with(SCHEMA_PREFIX));
+
+    let Some(schema_line) = schema_line else {
+        return Ok(());
+    };
+
+    let schema_url = schema_line
+        .trim()
+        .strip_prefix(SCHEMA_PREFIX)
+        .ok_or_else(|| anyhow!("Invalid schema directive in {}", toml_path.display()))?
+        .trim();
+
+    if !schema_url.starts_with("http://") && !schema_url.starts_with("https://") {
+        return Ok(());
+    }
+
+    let schema_filename = schema_url
+        .rsplit('/')
+        .next()
+        .ok_or_else(|| anyhow!("Invalid schema URL: {}", schema_url))?;
+
+    let local_schema_path = find_local_schema_file(schema_filename)?;
+
+    if let Ok(remote_hash) = fetch_and_hash_url(schema_url) {
+        let local_hash = text_file_hash(&local_schema_path)?;
+
+        if remote_hash == local_hash {
+            return Ok(());
+        }
+    }
+
+    let relative_path = calculate_relative_path(toml_path, &local_schema_path)?;
+    let new_schema_line = format!("#:schema {}", relative_path);
+
+    if schema_line.trim() == new_schema_line.trim() {
+        return Ok(());
+    }
+
+    rewrite_file_lines(toml_path, |line| {
+        if line.trim().starts_with(SCHEMA_PREFIX) {
+            new_schema_line.clone()
+        } else {
+            line.to_string()
+        }
+    })
+}
+
+/// Finds a local schema file by filename in the schema/json directory.
+fn find_local_schema_file(filename: &str) -> Result<PathBuf> {
+    let schema_dir = Path::new(JSON_SCHEMA_DIR);
+    let schema_path = schema_dir.join(filename);
+
+    if schema_path.exists() {
+        Ok(schema_path)
+    } else {
+        Err(anyhow!(
+            "Local schema file not found: {}",
+            schema_path.display()
+        ))
+    }
+}
+
+/// Fetches content from a URL and returns its SHA256 hash.
+/// Uses a 10-second timeout for the HTTP request.
+fn fetch_and_hash_url(url: &str) -> Result<Hash> {
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(std::time::Duration::from_secs(10)))
+        .build()
+        .new_agent();
+
+    let mut response = agent
+        .get(url)
+        .call()
+        .map_err(|e| anyhow!("Failed to fetch URL {}: {}", url, e))?;
+
+    text_reader_hash(std::io::BufReader::new(response.body_mut().as_reader()))
+}
+
+/// Computes the SHA256 hash of a text file.
+fn text_file_hash(path: &Path) -> Result<Hash> {
+    let file = File::open(path).map_err(|e| anyhow!("Failed to open {}: {}", path.display(), e))?;
+    text_reader_hash(file)
+}
+
+/// Computes the SHA256 hash of text content from a reader.
+/// Processes content line by line to ensure consistent hashing across platforms.
+fn text_reader_hash<R: std::io::Read>(reader: R) -> Result<Hash> {
+    let mut hasher = Sha256::new();
+    for line in std::io::BufReader::new(reader).lines() {
+        let line = line.map_err(|e| anyhow!("Failed to read line for hashing: {}", e))?;
+        hasher.update(line);
+        hasher.update(b"\n");
+    }
+    Ok(hasher.finalize().into())
+}
+
+/// Rewrites a file by applying a transformation function to each line.
+/// Preserves the final newline character if the original file had one.
+fn rewrite_file_lines<F>(path: &Path, transform: F) -> Result<()>
+where
+    F: Fn(&str) -> String,
+{
+    let content = fs::read_to_string(path)
+        .map_err(|e| anyhow!("Failed to read file {}: {}", path.display(), e))?;
+
+    let new_content: String = content
+        .lines()
+        .map(transform)
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let new_content = if content.ends_with('\n') {
+        format!("{}\n", new_content)
+    } else {
+        new_content
+    };
+
+    fs::write(path, new_content)
+        .map_err(|e| anyhow!("Failed to write file {}: {}", path.display(), e))?;
+
+    Ok(())
+}
+
+/// Calculates the relative path from one file to another.
+/// Used to generate relative schema paths in TOML files.
+fn calculate_relative_path(from: &Path, to: &Path) -> Result<String> {
+    let from_dir = from
+        .parent()
+        .ok_or_else(|| anyhow!("Failed to get parent directory of {}", from.display()))?;
+
+    let from_components: Vec<_> = from_dir.components().collect();
+    let to_components: Vec<_> = to.components().collect();
+
+    let common_len = from_components
+        .iter()
+        .zip(to_components.iter())
+        .take_while(|(a, b)| a == b)
+        .count();
+
+    let up_levels = from_components.len() - common_len;
+    let mut rel_path = String::new();
+
+    for _ in 0..up_levels {
+        rel_path.push_str("../");
+    }
+
+    for component in &to_components[common_len..] {
+        if let std::path::Component::Normal(comp) = component {
+            if !rel_path.is_empty() && !rel_path.ends_with('/') {
+                rel_path.push('/');
+            }
+            rel_path.push_str(
+                comp.to_str()
+                    .ok_or_else(|| anyhow!("Invalid path component"))?,
+            );
+        }
+    }
+
+    Ok(rel_path)
+}
+
+type Hash = [u8; 32];

--- a/cliff.toml
+++ b/cliff.toml
@@ -159,45 +159,38 @@ conventional_commits = true
 filter_unconventional = false
 split_commits = false
 commit_preprocessors = [
-    { pattern = '^(.*) \((#[0-9]+)\)', replace = "${1} by @{AUTHOR} in ${2}"},
-    { pattern = '^([a-z]+)(\([a-zA-Z0-9\-]+\))?: [Aa]dd (.*)$', replace = "${1}${2}: added ${3}"},
-    { pattern = '^([a-z]+)(\([a-zA-Z0-9\-]+\))?: [Ff]ix (.*)$', replace = "${1}${2}: fixed ${3}"},
-    { pattern = '^build\(deps\): bump the patch-updates group (across [0-9]+ director(y|ies) )?with [0-9]+ updates', replace = "build(deps): bump multiple patch updates"},
+    { pattern = '^(.*) \((#[0-9]+)\)', replace = "${1} by @{AUTHOR} in ${2}" },
+    { pattern = '^([a-z]+)(\([a-zA-Z0-9\-]+\))?: [Aa]dd (.*)$', replace = "${1}${2}: added ${3}" },
+    { pattern = '^([a-z]+)(\([a-zA-Z0-9\-]+\))?: [Ff]ix (.*)$', replace = "${1}${2}: fixed ${3}" },
+    { pattern = '^build\(deps\): bump the patch-updates group (across [0-9]+ director(y|ies) )?with [0-9]+ updates', replace = "build(deps): bump multiple patch updates" },
     # Zero-pad version numbers for proper alphanumeric sorting (e.g., 7.0.8 -> 7.z00000000.z00000008)
-    { pattern = '( from | to )([0-9]+)\.([0-9]+)\.([0-9]+)', replace = "${1}${2}.z00000000${3}.z00000000${4}"},
-    { pattern = 'z0*([0-9]{8})', replace = "z${1}"},
+    { pattern = '( from | to )([0-9]+)\.([0-9]+)\.([0-9]+)', replace = "${1}${2}.z00000000${3}.z00000000${4}" },
+    { pattern = "z0*([0-9]{8})", replace = "z${1}" },
 ]
 commit_parsers = [
     # Features - things that add new functionality
-    { message = '^feat(\(.+\))?: add', group = "<!-- 0 -->Added"},
-
+    { message = '^feat(\(.+\))?: add', group = "<!-- 0 -->Added" },
     # Changes - improvements, updates to existing functionality
-    { message = '^feat', group = "<!-- 1 -->Changed"},
-    { message = "^refactor", group = "<!-- 1 -->Changed"},
-    { message = "^change", group = "<!-- 1 -->Changed"},
-    { message = "^set.+minimum.+rust", group = "<!-- 1 -->Changed"},
-    { message = "^replace.*", group = "<!-- 1 -->Changed"},
-
+    { message = "^feat", group = "<!-- 1 -->Changed" },
+    { message = "^refactor", group = "<!-- 1 -->Changed" },
+    { message = "^change", group = "<!-- 1 -->Changed" },
+    { message = "^set.+minimum.+rust", group = "<!-- 1 -->Changed" },
+    { message = "^replace.*", group = "<!-- 1 -->Changed" },
     # Bug fixes
-    { message = "^fix", group = "<!-- 2 -->Fixed"},
-
+    { message = "^fix", group = "<!-- 2 -->Fixed" },
     # Performance improvements
-    { message = "^perf", group = "<!-- 3 -->Performance"},
-
+    { message = "^perf", group = "<!-- 3 -->Performance" },
     # Documentation
-    { message = "^docs?", group = "<!-- 4 -->Documentation"},
-    { message = "added.+examples", group = "<!-- 4 -->Documentation"},
-
+    { message = "^docs?", group = "<!-- 4 -->Documentation" },
+    { message = "added.+examples", group = "<!-- 4 -->Documentation" },
     # Dependencies - all dependency updates
-    { message = '^(build|chore)\(deps\).*patch.*', group = "<!-- 6 -->Dependencies", scope = "0-deps/2-patch"},
-    { message = '^(build|chore)\(deps\)', group = "<!-- 6 -->Dependencies", scope = "0-deps/1-other"},
-    { message = "^build\\(nix\\): update flake", group = "<!-- 6 -->Dependencies", scope = "2-nix/flake"},
-
+    { message = '^(build|chore)\(deps\).*patch.*', group = "<!-- 6 -->Dependencies", scope = "0-deps/2-patch" },
+    { message = '^(build|chore)\(deps\)', group = "<!-- 6 -->Dependencies", scope = "0-deps/1-other" },
+    { message = "^build\\(nix\\): update flake", group = "<!-- 6 -->Dependencies", scope = "2-nix/flake" },
     # Skip release commits
-    { message = "^chore\\(release\\)", skip = true},
-
+    { message = "^chore\\(release\\)", skip = true },
     # Everything else goes to Other (build, ci, chore, etc.)
-    { message = ".*", group = "<!-- 5 -->Other"},
+    { message = ".*", group = "<!-- 5 -->Other" },
 ]
 # Set group order - Fixed comes before Dependencies and Other
 protect_breaking_commits = false

--- a/contrib/bin/setup.sh
+++ b/contrib/bin/setup.sh
@@ -150,6 +150,18 @@ setup_taplo() {
     fi
 }
 
+setup_tombi() {
+    if [ ! -x "$(command -v tombi)" ]; then
+        if [ -x "$(command -v brew)" ]; then
+            brew install tombi
+        elif [ -x "$(command -v uv)" ]; then
+            uv add --dev tombi
+        else
+            echo "Please install tombi manually"
+        fi
+    fi
+}
+
 setup_gh() {
     if [ ! -x "$(command -v gh)" ]; then
         if [ -x "$(command -v brew)" ]; then
@@ -247,6 +259,7 @@ while [ $# -gt 0 ]; do
             setup_cargo_nightly
             ;;
         schema)
+            setup_tombi
             setup_taplo
             ;;
         coverage)

--- a/schema/json/config.schema.json
+++ b/schema/json/config.schema.json
@@ -1,62 +1,88 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "#/definitions/document",
-  "definitions": {
-    "document": {
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["auto", "dark", "light"]
+    },
+    "terminal": {
+      "$ref": "#/definitions/terminal"
+    },
+    "env": {
       "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "mode": {
-          "type": "string",
-          "enum": ["auto", "dark", "light"]
-        },
-        "terminal": {
-          "$ref": "#/definitions/terminal"
-        },
-        "env": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "propertyNames": {
-            "type": "string",
-            "minLength": 1
-          }
-        },
-        "font": {
-          "$ref": "#/definitions/font"
-        },
-        "padding": {
-          "$ref": "#/definitions/padding"
-        },
-        "theme": {
-          "$ref": "#/definitions/theme"
-        },
-        "window": {
-          "$ref": "#/definitions/window"
-        },
-        "rendering": {
-          "$ref": "#/definitions/rendering"
-        },
-        "fonts": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/font-item"
-          }
-        }
+      "additionalProperties": {
+        "type": "string"
+      },
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
       }
     },
+    "font": {
+      "$ref": "#/definitions/font"
+    },
+    "padding": {
+      "$ref": "#/definitions/padding"
+    },
+    "theme": {
+      "$ref": "#/definitions/theme"
+    },
+    "window": {
+      "$ref": "#/definitions/window"
+    },
+    "rendering": {
+      "$ref": "#/definitions/rendering"
+    },
+    "fonts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/fontItem"
+      }
+    }
+  },
+  "definitions": {
     "terminal": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "width": {
-          "type": "number"
+          "$ref": "#/definitions/dimension"
         },
         "height": {
-          "type": "number"
+          "$ref": "#/definitions/dimension"
         }
       }
+    },
+    "dimension": {
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "enum": ["auto"]
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "min": {
+              "type": "number"
+            },
+            "max": {
+              "type": "number"
+            },
+            "step": {
+              "type": "number"
+            },
+            "initial": {
+              "type": "number"
+            }
+          }
+        }
+      ]
     },
     "font": {
       "type": "object",
@@ -81,17 +107,17 @@
       "additionalProperties": false,
       "properties": {
         "normal": {
-          "$ref": "#/definitions/font-weight"
+          "$ref": "#/definitions/fontWeight"
         },
         "bold": {
-          "$ref": "#/definitions/font-weight"
+          "$ref": "#/definitions/fontWeight"
         },
         "faint": {
-          "$ref": "#/definitions/font-weight"
+          "$ref": "#/definitions/fontWeight"
         }
       }
     },
-    "font-weight": {
+    "fontWeight": {
       "type": "string",
       "enum": [
         "normal",
@@ -185,7 +211,7 @@
         }
       }
     },
-    "font-item": {
+    "fontItem": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/schema/json/theme.schema.json
+++ b/schema/json/theme.schema.json
@@ -1,22 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "#/definitions/document",
-  "definitions": {
-    "document": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "tags": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/tag"
-          }
-        },
-        "theme": {
-          "$ref": "#/definitions/theme"
-        }
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/tag"
       }
     },
+    "theme": {
+      "$ref": "#/definitions/theme"
+    }
+  },
+  "definitions": {
     "theme": {
       "type": "object",
       "additionalProperties": false,
@@ -59,19 +56,19 @@
       "additionalProperties": false,
       "properties": {
         "background": {
-          "$ref": "#/definitions/hex-color"
+          "$ref": "#/definitions/hexColor"
         },
         "foreground": {
-          "$ref": "#/definitions/hex-color"
+          "$ref": "#/definitions/hexColor"
         },
         "bright-foreground": {
-          "$ref": "#/definitions/hex-color"
+          "$ref": "#/definitions/hexColor"
         },
         "palette": {
           "type": "object",
           "patternProperties": {
             "^(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$": {
-              "$ref": "#/definitions/hex-color"
+              "$ref": "#/definitions/hexColor"
             }
           },
           "additionalProperties": false
@@ -79,7 +76,7 @@
       },
       "required": ["background", "foreground"]
     },
-    "hex-color": {
+    "hexColor": {
       "type": "string",
       "pattern": "^#[0-9a-fA-F]{6}$"
     }

--- a/schema/json/window-style.schema.json
+++ b/schema/json/window-style.schema.json
@@ -1,231 +1,221 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$ref": "#/definitions/window-style",
-  "definitions": {
-    "window-style": {
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "window": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "window": {
+        "margin": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "horizontal": { "type": "number" },
+                "vertical": { "type": "number" }
+              },
+              "required": ["horizontal", "vertical"]
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "left": { "type": "number" },
+                "right": { "type": "number" },
+                "top": { "type": "number" },
+                "bottom": { "type": "number" }
+              },
+              "required": ["left", "right", "top", "bottom"]
+            }
+          ]
+        },
+        "border": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "margin": {
-              "oneOf": [
-                {
-                  "type": "number"
-                },
-                {
+            "width": { "type": "number" },
+            "radius": { "type": "number" },
+            "gap": { "type": "number" },
+            "colors": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "outer": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "horizontal": { "type": "number" },
-                    "vertical": { "type": "number" }
+                    "dark": { "$ref": "#/definitions/hexColor" },
+                    "light": { "$ref": "#/definitions/hexColor" }
                   },
-                  "required": ["horizontal", "vertical"]
+                  "required": ["dark", "light"]
                 },
-                {
+                "inner": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "left": { "type": "number" },
-                    "right": { "type": "number" },
-                    "top": { "type": "number" },
-                    "bottom": { "type": "number" }
+                    "dark": { "$ref": "#/definitions/hexColor" },
+                    "light": { "$ref": "#/definitions/hexColor" }
                   },
-                  "required": ["left", "right", "top", "bottom"]
+                  "required": ["dark", "light"]
                 }
-              ]
+              },
+              "required": ["outer", "inner"]
+            }
+          },
+          "required": ["width", "radius", "colors"]
+        },
+        "header": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "color": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "dark": { "$ref": "#/definitions/hexColor" },
+                "light": { "$ref": "#/definitions/hexColor" }
+              },
+              "required": ["dark", "light"]
             },
+            "height": { "type": "number" },
             "border": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
                 "width": { "type": "number" },
-                "radius": { "type": "number" },
-                "gap": { "type": "number" },
-                "colors": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "outer": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "dark": { "$ref": "#/definitions/hex-color" },
-                        "light": { "$ref": "#/definitions/hex-color" }
-                      },
-                      "required": ["dark", "light"]
-                    },
-                    "inner": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "dark": { "$ref": "#/definitions/hex-color" },
-                        "light": { "$ref": "#/definitions/hex-color" }
-                      },
-                      "required": ["dark", "light"]
-                    }
-                  },
-                  "required": ["outer", "inner"]
-                }
-              },
-              "required": ["width", "radius", "colors"]
-            },
-            "header": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
                 "color": {
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "dark": { "$ref": "#/definitions/hex-color" },
-                    "light": { "$ref": "#/definitions/hex-color" }
+                    "dark": { "$ref": "#/definitions/hexColor" },
+                    "light": { "$ref": "#/definitions/hexColor" }
                   },
                   "required": ["dark", "light"]
-                },
-                "height": { "type": "number" },
-                "border": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "width": { "type": "number" },
-                    "color": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "properties": {
-                        "dark": { "$ref": "#/definitions/hex-color" },
-                        "light": { "$ref": "#/definitions/hex-color" }
-                      },
-                      "required": ["dark", "light"]
-                    }
-                  },
-                  "required": ["width", "color"]
                 }
               },
-              "required": ["color", "height", "border"]
-            },
-            "title": {
+              "required": ["width", "color"]
+            }
+          },
+          "required": ["color", "height", "border"]
+        },
+        "title": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "color": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "color": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "dark": { "$ref": "#/definitions/hex-color" },
-                    "light": { "$ref": "#/definitions/hex-color" }
-                  },
-                  "required": ["dark", "light"]
-                },
-                "font": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "family": {
-                      "type": "array",
-                      "items": { "type": "string" }
-                    },
-                    "size": { "type": "number" },
-                    "weight": { "type": "string" }
-                  },
-                  "required": ["family", "size", "weight"]
-                }
+                "dark": { "$ref": "#/definitions/hexColor" },
+                "light": { "$ref": "#/definitions/hexColor" }
               },
-              "required": ["color", "font"]
+              "required": ["dark", "light"]
             },
-            "buttons": {
+            "font": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "position": {
-                  "type": "string",
-                  "enum": ["left", "right", "top", "bottom"]
-                },
-                "shape": { "type": "string" },
-                "size": { "type": "number" },
-                "items": {
+                "family": {
                   "type": "array",
-                  "items": {
+                  "items": { "type": "string" }
+                },
+                "size": { "type": "number" },
+                "weight": { "type": "string" }
+              },
+              "required": ["family", "size", "weight"]
+            }
+          },
+          "required": ["color", "font"]
+        },
+        "buttons": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "position": {
+              "type": "string",
+              "enum": ["left", "right", "top", "bottom"]
+            },
+            "shape": { "type": "string" },
+            "size": { "type": "number" },
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "offset": { "type": "number" },
+                  "icon": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
-                      "offset": { "type": "number" },
-                      "icon": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "properties": {
-                          "kind": {
-                            "type": "string",
-                            "enum": ["close", "minimize", "maximize"]
-                          },
-                          "size": { "type": "number" },
-                          "stroke": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                              "dark": { "$ref": "#/definitions/hex-color" },
-                              "light": { "$ref": "#/definitions/hex-color" }
-                            },
-                            "required": ["dark", "light"]
-                          },
-                          "stroke-width": { "type": "number" },
-                          "stroke-linecap": { "type": "string" },
-                          "roundness": { "type": "number" }
-                        },
-                        "required": [
-                          "kind",
-                          "size",
-                          "stroke",
-                          "stroke-width",
-                          "stroke-linecap"
-                        ]
+                      "kind": {
+                        "type": "string",
+                        "enum": ["close", "minimize", "maximize"]
                       },
-                      "fill": { "$ref": "#/definitions/hex-color" },
+                      "size": { "type": "number" },
                       "stroke": {
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
-                          "dark": { "$ref": "#/definitions/hex-color" },
-                          "light": { "$ref": "#/definitions/hex-color" }
+                          "dark": { "$ref": "#/definitions/hexColor" },
+                          "light": { "$ref": "#/definitions/hexColor" }
                         },
                         "required": ["dark", "light"]
                       },
-                      "stroke-width": { "type": "number" }
+                      "stroke-width": { "type": "number" },
+                      "stroke-linecap": { "type": "string" },
+                      "roundness": { "type": "number" }
                     },
-                    "required": ["offset"]
-                  }
-                }
-              },
-              "required": ["position", "size", "items"]
-            },
-            "shadow": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "enabled": { "type": "boolean" },
-                "color": { "$ref": "#/definitions/hex-color" },
-                "blur": { "type": "number" },
-                "x": { "type": "number" },
-                "y": { "type": "number" }
-              },
-              "required": ["enabled", "color", "blur", "x", "y"]
+                    "required": [
+                      "kind",
+                      "size",
+                      "stroke",
+                      "stroke-width",
+                      "stroke-linecap"
+                    ]
+                  },
+                  "fill": { "$ref": "#/definitions/hexColor" },
+                  "stroke": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "dark": { "$ref": "#/definitions/hexColor" },
+                      "light": { "$ref": "#/definitions/hexColor" }
+                    },
+                    "required": ["dark", "light"]
+                  },
+                  "stroke-width": { "type": "number" }
+                },
+                "required": ["offset"]
+              }
             }
           },
-          "required": [
-            "margin",
-            "border",
-            "header",
-            "title",
-            "buttons",
-            "shadow"
-          ]
+          "required": ["position", "size", "items"]
+        },
+        "shadow": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "color": { "$ref": "#/definitions/hexColor" },
+            "blur": { "type": "number" },
+            "x": { "type": "number" },
+            "y": { "type": "number" }
+          },
+          "required": ["enabled", "color", "blur", "x", "y"]
         }
       },
-      "required": ["window"]
-    },
-    "hex-color": {
+      "required": ["margin", "border", "header", "title", "buttons", "shadow"]
+    }
+  },
+  "required": ["window"],
+  "definitions": {
+    "hexColor": {
       "type": "string",
       "pattern": "^#[0-9a-fA-F]{6,8}$"
     }

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,63 @@
+toml-version = "v1.0.0"
+
+[files]
+include = ["**/*.toml"]
+
+[format]
+[format.rules]
+array-bracket-space-width = 0
+array-comma-space-width = 1
+date-time-delimiter = "T"
+indent-style = "space"
+indent-sub-tables = false
+indent-table-key-value-pairs = false
+indent-width = 4
+inline-table-brace-space-width = 1
+inline-table-comma-space-width = 1
+key-value-equals-sign-alignment = false
+key-value-equals-sign-space-width = 1
+line-ending = "lf"
+line-width = 128
+string-quote-style = "double"
+trailing-comment-alignment = true
+trailing-comment-space-width = 1
+
+[lint]
+[lint.rules]
+dotted-keys-out-of-order = "warn"
+key-empty = "warn"
+tables-out-of-order = "warn"
+
+[lsp]
+code-action.enabled = true
+completion.enabled = true
+diagnostic.enabled = true
+document-link.enabled = true
+formatting.enabled = true
+goto-declaration.enabled = true
+goto-definition.enabled = true
+goto-type-definition.enabled = true
+hover.enabled = true
+workspace-diagnostic.enabled = true
+
+[schema]
+enabled = true
+strict = true
+
+[schema.catalog]
+paths = [
+    "tombi://www.schemastore.org/api/json/catalog.json",
+    "https://www.schemastore.org/api/json/catalog.json",
+]
+
+[[schemas]]
+path = "schema/json/config.schema.json"
+include = ["assets/config.toml"]
+
+[[schemas]]
+path = "schema/json/theme.schema.json"
+include = ["assets/themes/*.toml"]
+
+[[schemas]]
+path = "schema/json/window-style.schema.json"
+include = ["assets/window-styles/*.toml"]

--- a/tools/tidy-themes/Cargo.toml
+++ b/tools/tidy-themes/Cargo.toml
@@ -2,11 +2,10 @@
 name = "tidy-themes"
 version = "0.1.0"
 edition = "2024"
-authors = ["Pavel Ivanov <mr.pavel.ivanov@gmail.com>"]
 license = "MIT"
 
 [dependencies]
 anyhow = "1"
-voca_rs = "1"
-serde_json = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+voca_rs = "1"


### PR DESCRIPTION
### Changes
- Implement build script to replace HTTP(S) schema URLs with relative paths
- Add SHA256 hash validation to ensure local schemas match remote versions
- Replace schema URLs in config and theme TOML files with relative paths
- Add taplo and tombi validation to CI/CD workflows
- Add tombi.toml configuration for TOML linting
- Reformat JSON schema files for consistency
- Add setup script for development tools
- Enhance justfile with TOML validation targets

The build script now automatically:
- Scans all *.toml files in the assets directory
- Detects schema directives using HTTP(S) URLs
- Validates local schemas against remote versions via SHA256
- Replaces URLs with relative paths to local schema files

This ensures offline-first operation while maintaining schema validation.