### PR TITLE
fix(ci): correct schema URL pattern in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,10 +120,10 @@ jobs:
           # Find all TOML files with schema references (both relative and absolute) and update them
           # Matches both:
           # - Relative: #:schema (../)+schema/...
-          # - Absolute: #:schema https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/[ref]/schema/...
+          # - Absolute: #:schema https://raw.githubusercontent.com/${{ github.repository }}/[ref]/schema/...
           find . -name "*.toml" -type f -exec grep -l "#:schema" {} \; | while read -r file; do
             echo "Updating schema reference in ${file}"
-            sed -i.bak -E 's|#:schema ((\.\./)+\|https://raw\.githubusercontent\.com/${{ github.repository_owner }}/${{ github.repository }}/[^/]+/)schema/|#:schema https://raw.githubusercontent.com/${{ github.repository_owner }}/${{ github.repository }}/v'"${VERSION}"'/schema/|g' "${file}"
+            sed -i.bak -E 's|#:schema ((\.\./)+\|https://raw\.githubusercontent\.com/${{ github.repository }}/[^/]+/)schema/|#:schema https://raw.githubusercontent.com/${{ github.repository }}/v'"${VERSION}"'/schema/|g' "${file}"
             rm -f "${file}.bak"
           done
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "termframe"
-version = "0.7.5"
+version = "0.7.6-alpha.1"
 dependencies = [
  "allsorts",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termframe"
-version = "0.7.5"
+version = "0.7.6-alpha.1"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Terminal output SVG screenshot tool"

--- a/assets/config.toml
+++ b/assets/config.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/pamburus/pamburus/termframe/v0.7.5/schema/json/config.schema.json
+#:schema ../schema/json/config.schema.json
 
 # Dark or light mode.
 # Possible values: [auto, dark, light].

--- a/assets/themes/One Double.toml
+++ b/assets/themes/One Double.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/pamburus/pamburus/termframe/v0.7.5/schema/json/theme.schema.json
+#:schema ../../schema/json/theme.schema.json
 
 tags = ["dark", "light"]
 

--- a/assets/window-styles/compact.toml
+++ b/assets/window-styles/compact.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/pamburus/pamburus/termframe/v0.7.5/schema/json/window-style.schema.json
+#:schema ../../schema/json/window-style.schema.json
 
 [window]
 margin = 8

--- a/assets/window-styles/macos.toml
+++ b/assets/window-styles/macos.toml
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/pamburus/pamburus/termframe/v0.7.5/schema/json/window-style.schema.json
+#:schema ../../schema/json/window-style.schema.json
 
 [window.margin]
 left = 32


### PR DESCRIPTION
Use github.repository variable directly instead of combining repository_owner and repository separately to properly construct the schema URL for updating TOML file references.

Fixes #471 