### PR TITLE
build: improve schema fetch retry behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "termframe"
-version = "0.7.7-alpha.3"
+version = "0.7.7-alpha.4"
 dependencies = [
  "allsorts",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termframe"
-version = "0.7.7-alpha.3"
+version = "0.7.7-alpha.4"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Terminal output SVG screenshot tool"


### PR DESCRIPTION
- Cache both successful and failed fetch results to avoid repeated retries for the same failing URL across multiple TOML files
- Use exponential timeout (2s, 4s, 8s) instead of fixed 10s timeout
- Add info-level logging for fetch requests (visible with -vvv)