### PR TITLE
fix(changelog): fix padded version strings leaking into release notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3378,7 +3378,7 @@ dependencies = [
 
 [[package]]
 name = "termframe"
-version = "0.8.6"
+version = "0.8.7-alpha.1"
 dependencies = [
  "allsorts",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termframe"
-version = "0.8.6"
+version = "0.8.7-alpha.1"
 edition = "2024"
 rust-version = "1.91.0"
 description = "Terminal output SVG screenshot tool"

--- a/cliff.toml
+++ b/cliff.toml
@@ -2,11 +2,29 @@
 header = ""
 body = """
 {%- macro add_commit(message, author) -%}
-    - {{ message | trim | upper_first | replace(from="{AUTHOR}", to=author | replace(from="[bot]", to="")) }}
+    {%- set clean = self::strip_padding(version=message) -%}
+    - {{ clean | trim | upper_first | replace(from="{AUTHOR}", to=author | replace(from="[bot]", to="")) }}
 {% endmacro -%}
 
 {%- macro strip_padding(version) -%}
-    {{- version | replace(from=".z00000000", to=".0") | replace(from=".z0000000", to=".") | replace(from=".z000000", to=".") | replace(from=".z00000", to=".") | replace(from=".z0000", to=".") | replace(from=".z000", to=".") | replace(from=".z00", to=".") | replace(from=".z0", to=".") | replace(from=".z", to=".") -}}
+    {%- set v = version
+        | replace(from=".z00000000", to=".0")
+        | replace(from=".z0000000", to=".")
+        | replace(from=".z000000", to=".")
+        | replace(from=".z00000", to=".")
+        | replace(from=".z0000", to=".")
+        | replace(from=".z000", to=".")
+        | replace(from=".z00", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z0", to=".")
+        | replace(from=".z", to=".") -%}
+    {{- v -}}
 {%- endmacro -%}
 
 {%- macro bump_finalize(pkg, first_from, last_to, pr_numbers, author) -%}

--- a/contrib/bin/setup.sh
+++ b/contrib/bin/setup.sh
@@ -70,31 +70,44 @@ setup_cargo_nightly() {
     fi
 }
 
+setup_cargo_binstall() {
+    if [ -x "$(command -v cargo-binstall)" ]; then
+        true
+    elif [ -x "$(command -v scoop)" ]; then
+        scoop install cargo-binstall
+    elif [ -x "$(command -v cargo)" ]; then
+        cargo install cargo-binstall
+    else
+        echo "Please install cargo-binstall"
+        exit 1
+    fi
+}
+
 setup_cargo_audit() {
-    setup_cargo
     if [ ! -x "$(command -v cargo-audit)" ]; then
-        cargo install cargo-audit
+        setup_cargo_binstall
+        cargo binstall cargo-audit
     fi
 }
 
 setup_cargo_edit() {
-    setup_cargo
-    if [ ! cargo set-version --help >/dev/null 2>&1 ]; then
-        cargo install cargo-edit
+    if ! cargo set-version --help >/dev/null 2>&1; then
+        setup_cargo_binstall
+        cargo binstall cargo-edit
     fi
 }
 
 setup_cargo_outdated() {
-    setup_cargo
     if [ ! -x "$(command -v cargo-outdated)" ]; then
-        cargo install cargo-outdated
+        setup_cargo_binstall
+        cargo binstall cargo-outdated
     fi
 }
 
 setup_rustfilt() {
-    setup_cargo
     if [ ! -x "$(command -v rustfilt)" ]; then
-        cargo install rustfilt
+        setup_cargo_binstall
+        cargo binstall rustfilt
     fi
 }
 
@@ -122,17 +135,17 @@ setup_sed() {
 }
 
 setup_llvm_profdata() {
-    setup_rustup
-    setup_rustc
-    setup_sed
     if [ ! -x "$(command -v $(rustc --print sysroot)/lib/rustlib/$(rustc -vV | sed -n 's|host: ||p')/bin/llvm-profdata)" ]; then
+        setup_rustup
+        setup_rustc
+        setup_sed
         rustup component add llvm-tools-preview
     fi
 }
 
 setup_clippy() {
-    setup_rustup
     if ! (rustup component list | grep -q 'clippy.*(installed)'); then
+        setup_rustup
         rustup component add clippy
     fi
 }
@@ -144,9 +157,9 @@ setup_coverage_tools() {
 }
 
 setup_taplo() {
-    setup_cargo
     if [ ! -x "$(command -v taplo)" ]; then
-        cargo install taplo-cli --locked --features lsp
+        setup_cargo_binstall
+        cargo binstall taplo-cli --locked --features lsp
     fi
 }
 
@@ -158,6 +171,7 @@ setup_tombi() {
             uv add --dev tombi
         else
             echo "Please install tombi manually"
+            exit 1
         fi
     fi
 }
@@ -174,6 +188,7 @@ setup_gh() {
             sudo pacman -S gh
         else
             echo "Please install gh manually"
+            exit 1
         fi
     fi
 }
@@ -189,8 +204,8 @@ setup_git_cliff() {
         elif [ -x "$(command -v pacman)" ]; then
             sudo pacman -S git-cliff
         else
-            setup_cargo
-            cargo install git-cliff --locked
+            setup_cargo_binstall
+            cargo binstall git-cliff --locked
         fi
     fi
 }
@@ -206,8 +221,8 @@ setup_bat() {
         elif [ -x "$(command -v pacman)" ]; then
             sudo pacman -S bat
         else
-            setup_cargo
-            cargo install bat --locked
+            setup_cargo_binstall
+            cargo binstall bat --locked
         fi
     fi
 }

--- a/justfile
+++ b/justfile
@@ -1,8 +1,12 @@
 # Common settings
 
+set lazy
+
 fonts := "JetBrains Mono, Fira Code, Cascadia Code, Source Code Pro, Consolas, Menlo, Monaco, DejaVu Sans Mono, monospace"
 tmp-themes-dir := ".tmp/themes"
-previous-tag := "git tag -l \"v*.*.*\" --merged HEAD --sort=-version:refname | head -1"
+
+# Previous version tag
+previous-tag := shell("git tag -l \"v*.*.*\" --merged HEAD --sort=-version:refname | head -1")
 
 # NixOS helpers
 
@@ -53,10 +57,10 @@ version: (setup "cargo" "jq")
     @cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "termframe") | .version'
 
 [doc('List changes since the previous release')]
+[script]
 changes since="auto": (setup "git-cliff" "bat" "gh" "jq" "cargo")
-    #!/usr/bin/env bash
     set -euo pipefail
-    since=$(if [ "{{ since }}" = auto ]; then {{ previous-tag }}; else echo "{{ since }}"; fi)
+    since={{ if since == 'auto' { previous-tag } else { since } }}
     version=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "termframe") | .version')
     GITHUB_REPO=pamburus/termframe \
     GITHUB_TOKEN=$(gh auth token) \


### PR DESCRIPTION
* Version strings in release notes no longer contain zero-padding artifacts (e.g. `1.z0000002` → `1.2`)
* Dev tool setup now uses `cargo binstall` for faster installs when no OS package provides a tool
* Missing required tools now cause setup to fail with a clear error instead of silently continuing