### PR TITLE
ci: install rustfilt from a prebuilt binary in the coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
 
+    env:
+      # renovate: datasource=crate depName=rustfilt
+      RUSTFILT_VERSION: "0.2.1"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -86,6 +90,11 @@ jobs:
 
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Install coverage tools
+        uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # v2.82.6
+        with:
+          tool: rustfilt@${{ env.RUSTFILT_VERSION }}
 
       - name: Generate code coverage
         run: |

--- a/contrib/bin/setup.sh
+++ b/contrib/bin/setup.sh
@@ -76,7 +76,7 @@ setup_cargo_binstall() {
     elif [ -x "$(command -v scoop)" ]; then
         scoop install cargo-binstall
     elif [ -x "$(command -v cargo)" ]; then
-        cargo install cargo-binstall
+        cargo install cargo-binstall --locked
     else
         echo "Please install cargo-binstall"
         exit 1


### PR DESCRIPTION
The coverage job currently fails while bootstrapping cargo-binstall from source just to obtain `rustfilt` — binstall's transitive dependencies now require a newer Rust than the job's toolchain, so the run dies with `error: failed to compile cargo-binstall`.

* Install `rustfilt` as a pinned prebuilt binary via `taiki-e/install-action`, so nothing is compiled against the pinned toolchain and tool requirements no longer couple to ours
* Pass `--locked` to the cargo-binstall bootstrap so local setup resolves against its own tested lockfile

The action pin matches the `taiki-e/install-action` SHA already used by the theme update workflow, keeping it a single dependabot entry.

Ported from the equivalent fix in hl (pamburus/hl#1520).

## Verification

- [ ] The coverage job on this PR completes and uploads to codecov