### PR TITLE
build(deps): bump github/codeql-action to 4.36.3 and group its updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,17 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
+    groups:
+      codeql-action-sec:
+        applies-to: security-updates
+        patterns:
+          - "github/codeql-action"
+          - "github/codeql-action/*"
+      codeql-action-ver:
+        applies-to: version-updates
+        patterns:
+          - "github/codeql-action"
+          - "github/codeql-action/*"
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
Combines #673 and #675 into a single change, and stops the split from recurring.

Dependabot tracks `github/codeql-action/init` and `github/codeql-action/analyze` as separate dependencies, so it opened one pull request per action path. CodeQL requires every `github/codeql-action` step in a workflow to be on the same version, so each pull request on its own leaves the two steps mismatched and the Analyze jobs fail on both:

> Not all workflow steps that use `github/codeql-action` actions use the same version.

* Move both steps to 4.36.3 together, which is the state the two pull requests were collectively aiming at
* Add a dependabot group for `github/codeql-action` so future bumps arrive as one pull request

The group deliberately omits `update-types`, unlike the cargo groups — the cargo side routes patch updates through its catch-all `patch-updates` group, and the github-actions ecosystem has no such catch-all. A patch bump is exactly the case that broke here.

## Verification

- [x] Analyze jobs pass on this PR

Closes #673, #675 once merged.